### PR TITLE
Hide .git and .env from default Caddy config

### DIFF
--- a/bot/os/template/homeFile.txt
+++ b/bot/os/template/homeFile.txt
@@ -4,5 +4,7 @@
 http://<username>.hackclub.app {
 	bind unix/.webserver.sock|777
 	root * /home/<username>/pub
-	file_server
+	file_server {
+		hide .git .env
+	}
 }


### PR DESCRIPTION
Quick little thing to make sure Nest users don't accidentally expose their Git or environment variables!