### PR TITLE
Bind caddy admin to unix socket

### DIFF
--- a/bot/os/template/homeFile.txt
+++ b/bot/os/template/homeFile.txt
@@ -4,5 +4,7 @@
 http://<username>.hackclub.app {
 	bind unix/.webserver.sock|777
 	root * /home/<username>/pub
-	file_server
+	file_server {
+		hide .git .env
+	}
 }

--- a/bot/os/template/homeFile.txt
+++ b/bot/os/template/homeFile.txt
@@ -1,5 +1,5 @@
 {
-	admin off
+	admin unix//home/<username>/caddy-admin.sock
 }
 http://<username>.hackclub.app {
 	bind unix/.webserver.sock|777


### PR DESCRIPTION
So at first I thought Caddy admin wasn't needed, but after some testing and development I figured out that `caddy reload` doesn't work without Caddy admin enabled. Binding Caddy admin to a unix socket in the user's homedir avoids the issue we were having before of the admin ports conflicting but keeps it enabled and working.