### PR TITLE
Fix perms issue and combine setup scripts

### DIFF
--- a/bot/os/osFunctions.py
+++ b/bot/os/osFunctions.py
@@ -11,26 +11,9 @@ def generate_config(username):
         config = config.replace("<username>", username)
         append_to_caddyfile(config)
 
-
-def generate_configHome(username):
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    config_dir = os.path.join(current_dir, "template", "homeFile.txt")
-    with open(config_dir, "r") as file:
-        config = file.read()
-        config = config.replace("<username>", username)
-        write_to_home(username, config)
-
+def home_script(username):
+    os.system('sudo /home/nest-internal/nest-bot/bot/os/scripts/create_home.sh ' + username)
 
 def append_to_caddyfile(config):
     with open("/etc/caddy/Caddyfile", "a") as caddyfile:
         caddyfile.write(config)
-
-
-def write_to_home(username, config):
-    os.system('sudo /home/nest-internal/nest-bot/bot/os/scripts/create_home.sh ' + username)
-
-    caddyfile_path = f"/home/{username}/Caddyfile"
-    with open(caddyfile_path, "w") as caddyfile:
-        caddyfile.write(config)
-
-    os.system('sudo /home/nest-internal/nest-bot/bot/os/scripts/start_caddy.sh ' + username)

--- a/bot/os/scripts/create_home.sh
+++ b/bot/os/scripts/create_home.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
+
+# Init home directory
 shopt -s dotglob
 cp -r /etc/skel/* /home/$1
+
+# Generate Caddy config
+sed "s/<username>/$1/" /home/nest-internal/nest-bot/bot/os/template/homeFile.txt > /home/$1/Caddyfile
+
+# Set permissions
 chown -R $1:$(id -u $1) /home/$1
-chown $1:1001 /home/$1
-chown $1:1001 /home/$1/Caddyfile
-chmod 770 /home/$1
-chmod 770 /home/$1/Caddyfile
+chmod 700 /home/$1
+
+# Start Caddy
 systemctl --user -M $1@ daemon-reload
+systemctl --user -M $1@ start caddy

--- a/bot/os/scripts/start_caddy.sh
+++ b/bot/os/scripts/start_caddy.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-systemctl --user -M $1@ start caddy

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ import sys
 import json
 import string
 import random
-from bot.os.osFunctions import generate_config, generate_configHome, setup_script
+from bot.os.osFunctions import generate_config, home_script, setup_script
 import logging
 
 ROOT_URL = "https://identity.hackclub.app/api/v3/"
@@ -174,7 +174,7 @@ async def register_user(user: User):
 
         generate_config(user.username)
         setup_script(user.username)
-        generate_configHome(user.username)
+        home_script(user.username)
         logging.info(f"User configured{user.username}")
     except HTTPError as http_err:
         logging.error(f"HTTP error when trying to register and set password for the user {http_err}")


### PR DESCRIPTION
Removes the need for the `caddyConfigEditors` group which makes permissions in home dirs weird. Also combines a couple scripts into one.